### PR TITLE
Manage timer UI and functionality

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -83,6 +83,14 @@ function App() {
     pauseTimer()
   }, [pauseTimer])
 
+  const handleReset = useCallback(() => {
+    resetTimer()
+    // Automatically start the timer after reset
+    setTimeout(() => {
+      startTimer()
+    }, 50) // Small delay to ensure reset completes
+  }, [resetTimer, startTimer])
+
   const handleToggleStats = () => {
     setShowStats((prev) => !prev)
   }
@@ -137,7 +145,7 @@ function App() {
               customPresets={customPresets}
               onStart={startTimer}
               onPause={handlePause}
-              onReset={resetTimer}
+              onReset={handleReset}
               onSkip={handleSkip}
               onPresetSelect={updatePreset}
               onAddCustomPreset={handleAddCustomPreset}

--- a/src/components/Timer.jsx
+++ b/src/components/Timer.jsx
@@ -158,7 +158,7 @@ export function Timer({
             )}
           </div>
           
-          {/* Quick Time Adjustment Buttons */}
+          {/* Quick Time Adjustment Buttons - Hidden when timer is running */}
           {!isRunning && !isEditing && (
             <div className="space-y-2 mb-4">
               <div className="flex justify-center gap-2">
@@ -241,11 +241,14 @@ export function Timer({
           onSkip={onSkip}
         />
 
-        <PresetButtons 
-          onPresetSelect={onPresetSelect}
-          onAddCustomPreset={onAddCustomPreset}
-          customPresets={customPresets}
-        />
+        {/* Preset Buttons - Hidden when timer is running */}
+        {!isRunning && (
+          <PresetButtons 
+            onPresetSelect={onPresetSelect}
+            onAddCustomPreset={onAddCustomPreset}
+            customPresets={customPresets}
+          />
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
Hide timer presets and quick adjustment buttons when the timer is running for a cleaner UI, and make the reset button automatically restart the timer for improved usability.

---
<a href="https://cursor.com/background-agent?bcId=bc-6028e9b6-d2ba-428c-9d5b-4b79f855b2ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6028e9b6-d2ba-428c-9d5b-4b79f855b2ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

